### PR TITLE
feat: 지도 이동 시 주소 조회 성능 최적화

### DIFF
--- a/components/layout/kakao-map.tsx
+++ b/components/layout/kakao-map.tsx
@@ -177,7 +177,7 @@ const KakaoMap = ({ deviceType = "desktop" }: { deviceType?: Device }) => {
       const map = new window.kakao.maps.Map(mapContainer, mapOption);
       setMap(map);
 
-      const handleDrag = () => {
+      const handleCenterChange = () => {
         const latlng = map.getCenter();
         setCurLocation({
           lat: latlng.getLat(),
@@ -185,7 +185,8 @@ const KakaoMap = ({ deviceType = "desktop" }: { deviceType?: Device }) => {
         });
       };
 
-      window.kakao.maps.event.addListener(map, "dragend", handleDrag);
+      // Use 'idle' instead of 'dragend' to wait for animations/zoom to settle
+      window.kakao.maps.event.addListener(map, "idle", handleCenterChange);
 
       // Right-click event for PC
       window.kakao.maps.event.addListener(

--- a/components/pages/home/location-badge.tsx
+++ b/components/pages/home/location-badge.tsx
@@ -9,7 +9,7 @@ import { Loader2, Navigation } from "lucide-react";
 
 const LocationBadge = () => {
   // TODO: 주소 가져오기 이후 훅 분리 필요 (search/around-client 에서 사용 중)
-  const { region, geoLocationError } = useGeolocationStore();
+  const { region, regionLoading, geoLocationError } = useGeolocationStore();
   const { toast } = useToast();
 
   // Use GPS tracking hook for mobile
@@ -61,11 +61,16 @@ const LocationBadge = () => {
 
   return (
     <div className="flex items-center w-full web:justify-center mo:justify-between">
-      <Badge
-        text={title as string}
-        icon={<LocationIcon size={18} className="fill-primary" />}
-        className="pl-[5px] border-none"
-      />
+      <div className="flex items-center gap-1.5">
+        <Badge
+          text={title as string}
+          icon={<LocationIcon size={18} className="fill-primary" />}
+          className="pl-[5px] border-none"
+        />
+        {regionLoading && (
+          <Loader2 size={16} className="stroke-primary animate-spin" />
+        )}
+      </div>
       {/* Mobile GPS button - right aligned */}
       <button
         onClick={handleGps}

--- a/hooks/useAddressResolver.ts
+++ b/hooks/useAddressResolver.ts
@@ -1,0 +1,149 @@
+import getAddress from "@api/common/get-address";
+import { addressCache, type CachedRegion } from "@lib/address-cache";
+import { useCallback, useRef, useState } from "react";
+
+const DEBOUNCE_MS = 500;
+
+interface ResolveResult {
+  success: boolean;
+  data?: CachedRegion;
+  error?: string;
+}
+
+export const useAddressResolver = () => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const debounceTimer = useRef<NodeJS.Timeout | null>(null);
+  const abortController = useRef<AbortController | null>(null);
+  const requestToken = useRef<number>(0);
+
+  /**
+   * Resolve address with debouncing and caching
+   * Returns immediately from cache if available
+   * Otherwise debounces the API call
+   */
+  const resolve = useCallback(
+    (lat: number, lng: number): Promise<ResolveResult> => {
+      // Check cache first
+      const cached = addressCache.get(lat, lng);
+      if (cached) {
+        setError(null);
+        return Promise.resolve({ success: true, data: cached });
+      }
+
+      // Return a promise that will resolve after debounce
+      return new Promise((resolvePromise) => {
+        // Clear previous debounce timer
+        if (debounceTimer.current) {
+          clearTimeout(debounceTimer.current);
+        }
+
+        // Abort previous fetch
+        if (abortController.current) {
+          abortController.current.abort();
+        }
+
+        // Increment token to track latest request
+        const currentToken = ++requestToken.current;
+
+        // Start debounce
+        debounceTimer.current = setTimeout(async () => {
+          // Create new abort controller for this request
+          abortController.current = new AbortController();
+          setLoading(true);
+          setError(null);
+
+          try {
+            const response = await getAddress({ lat, lng });
+
+            // Ignore if this is not the latest request
+            if (currentToken !== requestToken.current) {
+              resolvePromise({ success: false, error: "Request cancelled" });
+              return;
+            }
+
+            if (response.code === -2) {
+              const errorMsg = "위치 정보 없음";
+              setError(errorMsg);
+              setLoading(false);
+              resolvePromise({ success: false, error: errorMsg });
+              return;
+            }
+
+            if (!response.documents || response.documents.length === 0) {
+              const errorMsg = "주소를 찾을 수 없습니다";
+              setError(errorMsg);
+              setLoading(false);
+              resolvePromise({ success: false, error: errorMsg });
+              return;
+            }
+
+            const {
+              address_name,
+              code,
+              region_1depth_name,
+              region_2depth_name,
+              region_3depth_name,
+              region_4depth_name,
+              region_type,
+            } = response.documents[0];
+
+            const regionData: CachedRegion = {
+              address_name,
+              code,
+              region_1depth_name,
+              region_2depth_name,
+              region_3depth_name,
+              region_4depth_name,
+              region_type,
+              timestamp: Date.now(),
+            };
+
+            // Store in cache
+            addressCache.set(lat, lng, regionData);
+
+            setLoading(false);
+            setError(null);
+            resolvePromise({ success: true, data: regionData });
+          } catch (err) {
+            // Ignore if this is not the latest request
+            if (currentToken !== requestToken.current) {
+              resolvePromise({ success: false, error: "Request cancelled" });
+              return;
+            }
+
+            const errorMsg =
+              err instanceof Error ? err.message : "주소 조회 실패";
+            setError(errorMsg);
+            setLoading(false);
+            resolvePromise({ success: false, error: errorMsg });
+          }
+        }, DEBOUNCE_MS);
+      });
+    },
+    []
+  );
+
+  /**
+   * Cancel any pending requests
+   */
+  const cancel = useCallback(() => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
+    if (abortController.current) {
+      abortController.current.abort();
+      abortController.current = null;
+    }
+    setLoading(false);
+  }, []);
+
+  return {
+    resolve,
+    cancel,
+    loading,
+    error,
+  };
+};

--- a/lib/address-cache.ts
+++ b/lib/address-cache.ts
@@ -1,0 +1,155 @@
+/**
+ * LRU Cache for geocoding results with sessionStorage persistence
+ * - Keys are rounded to 4 decimals (~11m precision)
+ * - TTL: 24 hours
+ * - Max 200 entries
+ */
+
+export interface CachedRegion {
+  address_name: string;
+  code: string;
+  region_1depth_name: string;
+  region_2depth_name: string;
+  region_3depth_name: string;
+  region_4depth_name: string;
+  region_type: string;
+  timestamp: number;
+}
+
+interface CacheEntry {
+  data: CachedRegion;
+  timestamp: number;
+}
+
+const MAX_CACHE_SIZE = 200;
+const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const STORAGE_KEY = "addressCacheV1";
+
+class AddressCache {
+  private cache: Map<string, CacheEntry>;
+
+  constructor() {
+    this.cache = new Map();
+    this.loadFromStorage();
+  }
+
+  /**
+   * Round coordinates to 4 decimals (~11m precision)
+   */
+  private getCacheKey(lat: number, lng: number): string {
+    return `${lat.toFixed(4)}:${lng.toFixed(4)}`;
+  }
+
+  /**
+   * Check if cached entry is still valid (within TTL)
+   */
+  private isValid(entry: CacheEntry): boolean {
+    return Date.now() - entry.timestamp < TTL_MS;
+  }
+
+  /**
+   * Get cached region data if available and valid
+   */
+  get(lat: number, lng: number): CachedRegion | null {
+    const key = this.getCacheKey(lat, lng);
+    const entry = this.cache.get(key);
+
+    if (!entry) return null;
+
+    if (!this.isValid(entry)) {
+      // Remove expired entry
+      this.cache.delete(key);
+      return null;
+    }
+
+    // Move to end (LRU - most recently used)
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+
+    return entry.data;
+  }
+
+  /**
+   * Store region data in cache
+   */
+  set(lat: number, lng: number, data: CachedRegion): void {
+    const key = this.getCacheKey(lat, lng);
+    const entry: CacheEntry = {
+      data,
+      timestamp: Date.now(),
+    };
+
+    // If cache is full, remove oldest entry (first item in Map)
+    if (this.cache.size >= MAX_CACHE_SIZE) {
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey) {
+        this.cache.delete(firstKey);
+      }
+    }
+
+    this.cache.set(key, entry);
+    this.saveToStorage();
+  }
+
+  /**
+   * Load cache from sessionStorage
+   */
+  private loadFromStorage(): void {
+    if (typeof window === "undefined") return;
+
+    try {
+      const stored = sessionStorage.getItem(STORAGE_KEY);
+      if (!stored) return;
+
+      const parsed: [string, CacheEntry][] = JSON.parse(stored);
+      const now = Date.now();
+
+      // Only load valid entries
+      for (const [key, entry] of parsed) {
+        if (now - entry.timestamp < TTL_MS) {
+          this.cache.set(key, entry);
+        }
+      }
+    } catch (error) {
+      console.warn("Failed to load address cache from storage:", error);
+    }
+  }
+
+  /**
+   * Save cache to sessionStorage
+   */
+  private saveToStorage(): void {
+    if (typeof window === "undefined") return;
+
+    try {
+      const entries = Array.from(this.cache.entries());
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    } catch (error) {
+      console.warn("Failed to save address cache to storage:", error);
+    }
+  }
+
+  /**
+   * Clear all cached data
+   */
+  clear(): void {
+    this.cache.clear();
+    if (typeof window !== "undefined") {
+      try {
+        sessionStorage.removeItem(STORAGE_KEY);
+      } catch (error) {
+        console.warn("Failed to clear address cache storage:", error);
+      }
+    }
+  }
+
+  /**
+   * Get current cache size
+   */
+  size(): number {
+    return this.cache.size;
+  }
+}
+
+// Singleton instance
+export const addressCache = new AddressCache();

--- a/store/useGeolocationStore.ts
+++ b/store/useGeolocationStore.ts
@@ -17,10 +17,12 @@ interface Region {
 
 interface GeolocationState {
   region: Region | null;
+  regionLoading: boolean;
   myLocation: Location | null;
   curLocation: Location;
   geoLocationError: null | string;
   setRegion: (region: Region) => void;
+  setRegionLoading: (loading: boolean) => void;
   setMyLocation: (myLocation: Location) => void;
   setCurLocation: (curLocation: Location) => void;
   setGeoLocationError: (error: string | null) => void;
@@ -28,6 +30,7 @@ interface GeolocationState {
 
 const useGeolocationStore = create<GeolocationState>()((set) => ({
   region: null,
+  regionLoading: false,
   /**
    * 현재 유저 위치
    */
@@ -40,6 +43,7 @@ const useGeolocationStore = create<GeolocationState>()((set) => ({
   setMyLocation: (myLocation) => set({ myLocation }),
   setCurLocation: (curLocation) => set({ curLocation }),
   setRegion: (region: Region) => set({ region }),
+  setRegionLoading: (regionLoading: boolean) => set({ regionLoading }),
   setGeoLocationError: (error) => set({ geoLocationError: error }),
 }));
 


### PR DESCRIPTION
- LRU 캐시 + sessionStorage로 중복 API 호출 방지 (24시간 TTL, 200개 한도)
- 500ms 디바운싱으로 빠른 이동 시 API 스팸 방지
- 좌표 4자리 반올림(~11m 정밀도)으로 캐시 히트율 향상
- AbortController로 race condition 처리
- 주소 로딩 중 스피너 표시로 UX 개선
- 지도 이벤트를 dragend → idle로 변경하여 애니메이션 완료 후 조회

관련 파일:
- lib/address-cache.ts: LRU 캐시 구현
- hooks/useAddressResolver.ts: 디바운싱 + 캐싱 훅
- store/useGeolocationStore.ts: regionLoading 상태 추가
- components/provider/geo-provider.tsx: 새 resolver 적용
- components/pages/home/location-badge.tsx: 로딩 스피너 추가
- components/layout/kakao-map.tsx: idle 이벤트로 변경


yarn lint 끝