### PR TITLE
refactor: 메인 네비게이션 아이콘 개선

### DIFF
--- a/components/common/side-main.tsx
+++ b/components/common/side-main.tsx
@@ -9,7 +9,7 @@ import useScrollRefStore from "@store/useScrollRefStore";
 import useSheetHeightStore from "@store/useSheetHeightStore";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { BsBuilding, BsChatDots, BsEmojiWink, BsGeo } from "react-icons/bs";
+import { BsHouseDoorFill, BsChatDots, BsPersonCircle, BsGeoAlt } from "react-icons/bs";
 import SheetHeightProvider from "../provider/sheet-height-provider";
 import Text from "./text";
 
@@ -35,8 +35,8 @@ interface SideMainProps {
 const menus = [
   {
     name: "홈",
-    icon: <BsBuilding size={22} className="fill-grey" />,
-    iconActive: <BsBuilding size={22} className="fill-primary" />,
+    icon: <BsHouseDoorFill size={22} className="fill-grey" />,
+    iconActive: <BsHouseDoorFill size={22} className="fill-primary" />,
     path: "/",
   },
   {
@@ -47,14 +47,14 @@ const menus = [
   },
   {
     name: "등록",
-    icon: <BsGeo size={22} className="fill-grey" />,
-    iconActive: <BsGeo size={22} className="fill-primary" />,
+    icon: <BsGeoAlt size={22} className="fill-grey" />,
+    iconActive: <BsGeoAlt size={22} className="fill-primary" />,
     path: "/register",
   },
   {
     name: "내 정보",
-    icon: <BsEmojiWink size={22} className="fill-grey" />,
-    iconActive: <BsEmojiWink size={22} className="fill-primary" />,
+    icon: <BsPersonCircle size={22} className="fill-grey" />,
+    iconActive: <BsPersonCircle size={22} className="fill-primary" />,
     path: "/mypage",
   },
 ];


### PR DESCRIPTION
기존 아이콘이 메뉴 의미와 맞지 않는 문제 해결:
- 홈: BsBuilding → BsHouseDoorFill (건물 → 집 아이콘)
- 소셜: BsChatDots 유지 (적합함)
- 등록: BsGeo → BsGeoAlt (위치 핀 개선)
- 내 정보: BsEmojiWink → BsPersonCircle (이모지 → 프로필 아이콘)

<img width="350" height="78" alt="image" src="https://github.com/user-attachments/assets/1b2384ec-1396-4e9e-9ad8-379c5a8932c2" />

->

<img width="382" height="79" alt="image" src="https://github.com/user-attachments/assets/13964f96-d2fa-4e88-ac29-83ff2c61fbc3" />
