### PR TITLE
feat: 개별 사진 삭제 기능 추가

### DIFF
--- a/app/pullup/[id]/pullup-client.tsx
+++ b/app/pullup/[id]/pullup-client.tsx
@@ -53,6 +53,7 @@ const PullupClient = ({
 
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number>(0);
+  const [markerPhotos, setMarkerPhotos] = useState(marker.photos || []);
 
   const sectionRefs = useRef<(HTMLDivElement | null)[]>([]);
 
@@ -71,6 +72,12 @@ const PullupClient = ({
     );
     setProviderInfo([...newComment]);
     setDeleteLoading(false);
+  };
+
+  const handlePhotoDeleted = (photoId: number) => {
+    setMarkerPhotos((prevPhotos) =>
+      prevPhotos.filter((photo) => photo.photoId !== photoId)
+    );
   };
 
   const onScroll = useCallback(
@@ -129,7 +136,7 @@ const PullupClient = ({
         markerId={marker.markerId}
       />
 
-      <ImageCarousel photos={marker.photos} />
+      <ImageCarousel photos={markerPhotos} />
 
       <Section className="py-0">
         <div className="flex items-center mt-2 flex-wrap">
@@ -305,7 +312,13 @@ const PullupClient = ({
               router.push(`/pullup/${marker.markerId}/report`)
             }
           />
-          <ImageList photos={marker.photos} />
+          <ImageList
+            photos={markerPhotos}
+            markerId={marker.markerId}
+            markerUserId={marker.userId}
+            isAdmin={marker.isChulbong || false}
+            onPhotoDeleted={handlePhotoDeleted}
+          />
         </Section>
       </div>
 

--- a/lib/api/marker/delete-marker-photo.ts
+++ b/lib/api/marker/delete-marker-photo.ts
@@ -1,0 +1,45 @@
+import fetchData from "@lib/fetchData";
+
+export interface DeleteMarkerPhotoResponse {
+  message: string;
+}
+
+export interface DeleteMarkerPhotoError {
+  error: string;
+}
+
+/**
+ * Deletes a single photo from a marker
+ *
+ * Backend endpoint: DELETE /api/v1/markers/{markerID}/photos/{photoID}
+ *
+ * Authorization: Owner or Admin only
+ *
+ * Response semantics:
+ * - 200: Photo deleted successfully OR photo already absent (idempotent)
+ * - 403: Unauthorized (not owner or admin)
+ * - 400: Invalid parameters
+ * - 500: Internal server error
+ *
+ * The response includes `X-Idempotent: true` header for idempotent operations.
+ *
+ * @param markerId - The marker ID
+ * @param photoId - The photo ID to delete
+ * @returns Promise with response (message or error)
+ */
+const deleteMarkerPhoto = async (
+  markerId: number,
+  photoId: number
+): Promise<Response> => {
+  const response = await fetchData(
+    `/api/v1/markers/${markerId}/photos/${photoId}`,
+    {
+      method: "DELETE",
+      credentials: "include",
+    }
+  );
+
+  return response;
+};
+
+export default deleteMarkerPhoto;


### PR DESCRIPTION
- 개별 사진 삭제 API 함수 추가 (멱등성 지원)
- ImageList 컴포넌트에 소유자/관리자용 삭제 버튼 추가
- pullup-client에 사진 상태 관리 추가
- 삭제 전 확인 다이얼로그 표시
- 토스트 알림으로 성공/에러 처리
- 백엔드의 멱등성 삭제 지원 (성공과 이미 삭제된 경우 모두 200 반환)

권한: 소유자 또는 관리자만 가능
UI: 권한이 있는 사용자에게 X 아이콘 삭제 버튼 표시