### PR TITLE
fix: 드로워 드래그 영역을 핸들로만 제한하여 스크롤 충돌 해결

### DIFF
--- a/components/common/side-main.tsx
+++ b/components/common/side-main.tsx
@@ -170,7 +170,6 @@ const SideMain = ({
           className
         )}
         style={{ height: isMobile && !fullHeight ? `${curHeight}%` : "" }}
-        onPointerDown={dragStart}
       >
         <button
           className="absolute top-3 -right-12 flex items-center justify-center 
@@ -193,17 +192,15 @@ const SideMain = ({
           />
         )}
 
-        {!fullHeight && (
+        {!fullHeight && dragable && (
           <div
-            className="sticky top-0 py-3 bg-white dark:bg-black z-20 rounded-t-3xl web:hidden"
-            data-type="scoroll-status-bar"
+            className="sticky top-0 py-3 bg-white dark:bg-black z-20 rounded-t-3xl web:hidden cursor-grab active:cursor-grabbing"
+            onPointerDown={dragStart}
+            role="button"
+            aria-label="드로워 높이 조절"
+            tabIndex={0}
           >
-            <div
-              className={`w-1/6 h-1 mx-auto rounded-lg ${
-                !dragable ? "bg-white dark:bg-black" : "bg-grey"
-              }`}
-              data-type="scoroll-status-bar"
-            />
+            <div className="w-1/6 h-1 mx-auto rounded-lg bg-grey" />
           </div>
         )}
 
@@ -219,9 +216,6 @@ const SideMain = ({
             deviceType === "ios-mobile-app" ? "pb-20" : "",
             bodyStyle
           )}
-          onPointerDown={(e) => {
-            e.stopPropagation();
-          }}
           onScroll={onScroll}
         >
           {children}


### PR DESCRIPTION
## 변경 사항

### 모바일 UX 개선
- **문제**: 전체 영역에서 드래그 감지로 인해 콘텐츠 스크롤 시 드로워가 의도치 않게 움직임
- **해결**: 드래그 핸들(회색 바)에만 드래그 기능 제한
- 접근성 개선
  - 커서 피드백 추가 (`cursor-grab` / `cursor-grabbing`)
  - ARIA 속성 추가 (스크린 리더 지원)
  - 키보드 포커스 가능 (`tabIndex={0}`)
- 불필요한 코드 제거
  - 콘텐츠 영역 `stopPropagation` 제거
  - 사용하지 않는 `data-type` 속성 제거
  - `dragable=false` 시 핸들 렌더링 생략